### PR TITLE
Fix code scanning alert no. 9: Unsafe HTML constructed from library input

### DIFF
--- a/jet/static/jet/js/src/features/jquery.ui.timepicker.js
+++ b/jet/static/jet/js/src/features/jquery.ui.timepicker.js
@@ -38,6 +38,8 @@
                              ->T-Rex<-
 */
 
+import DOMPurify from 'dompurify';
+
 (function ($) {
 
     $.extend($.ui, { timepicker: { version: "0.3.3"} });
@@ -544,11 +546,11 @@
                 hourCounter = 0,
                 hourLabel = this._get(inst, 'hourText'),
                 showCloseButton = this._get(inst, 'showCloseButton'),
-                closeButtonText = this._get(inst, 'closeButtonText'),
+                closeButtonText = DOMPurify.sanitize(this._get(inst, 'closeButtonText')),
                 showNowButton = this._get(inst, 'showNowButton'),
-                nowButtonText = this._get(inst, 'nowButtonText'),
+                nowButtonText = DOMPurify.sanitize(this._get(inst, 'nowButtonText')),
                 showDeselectButton = this._get(inst, 'showDeselectButton'),
-                deselectButtonText = this._get(inst, 'deselectButtonText'),
+                deselectButtonText = DOMPurify.sanitize(this._get(inst, 'deselectButtonText')),
                 showButtonPanel = showCloseButton || showNowButton || showDeselectButton;
 
 

--- a/package.json
+++ b/package.json
@@ -27,5 +27,7 @@
     "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "dompurify": "^3.2.3"
+  }
 }


### PR DESCRIPTION
Fixes [https://github.com/aksharahegde/django-jet-3-calm/security/code-scanning/9](https://github.com/aksharahegde/django-jet-3-calm/security/code-scanning/9)

To fix the problem, we need to ensure that any user input used to construct HTML is properly sanitized or escaped to prevent XSS attacks. The best way to fix this issue without changing existing functionality is to use a library like `DOMPurify` to sanitize the input before using it in the HTML construction.

1. Import the `DOMPurify` library.
2. Sanitize the `closeButtonText`, `nowButtonText`, and `deselectButtonText` before using them in the HTML construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
