### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe HTML constructed from library input

### DIFF
--- a/jet/static/jet/js/src/features/jquery.ui.timepicker.js
+++ b/jet/static/jet/js/src/features/jquery.ui.timepicker.js
@@ -38,7 +38,7 @@
                              ->T-Rex<-
 */
 
-const DOMPurify = require('dompurify');
+
 
 (function ($) {
 
@@ -274,7 +274,7 @@ const DOMPurify = require('dompurify');
             var isRTL = this._get(inst, 'isRTL');
             if (inst.append) { inst.append.remove(); }
             if (appendText) {
-                inst.append = $('<span class="' + this._appendClass + '">' + appendText + '</span>');
+                inst.append = $('<span class="' + this._appendClass + '"></span>').text(appendText);
                 input[isRTL ? 'before' : 'after'](inst.append);
             }
             input.unbind('focus.timepicker', this._showTimepicker);


### PR DESCRIPTION
Potential fix for [https://github.com/aksharahegde/django-jet-3-calm/security/code-scanning/8](https://github.com/aksharahegde/django-jet-3-calm/security/code-scanning/8)

To address the issue, we should ensure that the `appendText` value is safely rendered, such that user-supplied data cannot be used to inject malicious HTML/JavaScript. There are two main ways:

1. **Sanitize the input** using an HTML sanitizer or escape unsafe characters.
2. **Use a safe DOM API** to insert text, e.g., by creating the `<span>` and setting its `.text()` property, rather than building HTML with string concatenation.

The most robust and widely compatible fix (does not modify any plugin functionality) is to use jQuery's `.text()` to set the contents of the span, instead of inserting raw HTML with string substitution. Specifically, on line 277, rather than:
```js
inst.append = $('<span class="' + this._appendClass + '">' + appendText + '</span>');
```
We should:
```js
inst.append = $('<span class="' + this._appendClass + '"></span>').text(appendText);
```
This way, `appendText` is rendered as text, not parsed as HTML, preventing XSS.  
No new imports are strictly necessary, as jQuery is already used. Remove the unnecessary `require('dompurify')` since it's not actually used in this code (line 41).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
