### PR TITLE
fix(security): pin qs to 6.15.2 for CVE-2026-8723

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to django-jet-calm will be documented in this file.
 
+## [Unreleased]
+
+### Security
+- Pinned transitive `qs` to 6.15.2 to address CVE-2026-8723 (GHSA-q8mj-m7cp-5q26)
+
 ## [5.3.14] - 2026-04-11
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   },
   "scripts": {
     "build": "gulp build"
+  },
+  "resolutions": {
+    "qs": "6.15.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,10 +2352,10 @@ punycode@^1.3.2, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
 
-qs@^6.12.3:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
-  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
+qs@6.15.2, qs@^6.12.3:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
Addresses Dependabot alert #103 (GHSA-q8mj-m7cp-5q26) via yarn resolutions for the browserify/url transitive dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Patched a security vulnerability in a project dependency to enhance application security and protect against potential risks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aksharahegde/django-jet-3-calm/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->