### PR TITLE
fix(security): upgrade Django to 5.2.14 for CVE-2026-5766

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to django-jet-calm will be documented in this file.
 
+## [Unreleased]
+
+### Security
+- Upgraded Django to 5.2.14 to address CVE-2026-5766 (GHSA-w26r-rmm8-9c29)
+
 ## [5.3.14] - 2026-04-11
 
 ### Security

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django==5.2.13
+django==5.2.14
 six==1.17.0
 # django-rangefilter==0.9.1


### PR DESCRIPTION
Addresses Dependabot alert #98 (GHSA-w26r-rmm8-9c29) by pinning Django to the first patched 5.2.x release.