### PR TITLE
fix(tests): restore compatibility with Django 5.2 admin APIs

### DIFF
--- a/jet/tests/test_filters.py
+++ b/jet/tests/test_filters.py
@@ -43,10 +43,11 @@ class FiltersTestCase(TestCase):
 
     def test_related_field_ajax_list_filter_with_initial(self):
         initial = self.models[1]
-        request = self.factory.get("url", {"field__id__exact": initial.pk})
+        request = self.factory.get("url")
         field, lookup_params, model, model_admin, field_path = (
             self.get_related_field_ajax_list_filter_params()
         )
+        lookup_params["field__id__exact"] = str(initial.pk)
         list_filter = RelatedFieldAjaxListFilter(
             field, request, lookup_params, model, model_admin, field_path
         )

--- a/jet/tests/test_tags.py
+++ b/jet/tests/test_tags.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -14,6 +15,10 @@ class TagsTestCase(TestCase):
     def setUp(self):
         self.models = []
         self.searchable_models = []
+        self.user = User.objects.create_superuser(
+            "admin", "admin@example.com", "password"
+        )
+        self.factory = RequestFactory()
 
         self.models.append(TestModel.objects.create(field1="first", field2=1))
         self.models.append(TestModel.objects.create(field1="second", field2=2))
@@ -23,6 +28,11 @@ class TagsTestCase(TestCase):
         self.searchable_models.append(
             SearchableTestModel.objects.create(field1="second", field2=2)
         )
+
+    def _admin_request(self, url):
+        request = self.factory.get(url)
+        request.user = self.user
+        return request
 
     def test_select2_lookups(self):
         class TestForm(forms.Form):
@@ -83,7 +93,7 @@ class TagsTestCase(TestCase):
         context = {
             "original": instance,
             "preserved_filters": preserved_filters,
-            "request": RequestFactory().get(expected_url),
+            "request": self._admin_request(expected_url),
         }
 
         actual_url = jet_next_object(context)["url"]
@@ -108,7 +118,7 @@ class TagsTestCase(TestCase):
         context = {
             "original": instance,
             "preserved_filters": preserved_filters,
-            "request": RequestFactory().get(changelist_url),
+            "request": self._admin_request(changelist_url),
         }
 
         previous_object = jet_previous_object(context)


### PR DESCRIPTION
## Summary
- Fix sibling-object tag tests by attaching a superuser to `RequestFactory` requests so Django 5.2 admin `get_actions()` permission checks succeed
- Fix related-field ajax filter test by passing `field__id__exact` in `lookup_params` (the dict `RelatedFieldListFilter` reads) instead of only on `request.GET`

## Test plan
- [x] `python manage.py test jet` — 37/37 passing on Django 5.2.14 / Python 3.14


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure and refactored test utilities for better maintainability and consistency across test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->