### PR TITLE
build(deps): upgrade backend Python dependency constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "Django>=4.0",
-    "six",
-    "django-rangefilter",
+    "Django>=5.2.15",
+    "six>=1.17.0",
+    "django-rangefilter>=0.9.1",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-django==5.2.14
+django==5.2.15
 six==1.17.0
-# django-rangefilter==0.9.1
+django-rangefilter==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 
 def get_install_requires():
-    install_requires = ["Django", "six", "django-rangefilter"]
+    install_requires = ["Django>=5.2.15", "six>=1.17.0", "django-rangefilter>=0.9.1"]
 
     try:
         pass


### PR DESCRIPTION
## Summary
- upgrade Django from `5.2.14` to `5.2.15` in `requirements.txt`
- align backend dependency constraints across `requirements.txt`, `pyproject.toml`, and `setup.py`
- activate and pin `django-rangefilter` in `requirements.txt` to match backend package metadata

## Test plan
- [x] `python3 -m venv .venv`
- [x] `.venv/bin/python -m pip install -r requirements.txt`
- [x] `.venv/bin/python -m pip check`
- [x] `.venv/bin/python manage.py check` (passes with existing `models.W042` warnings only)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core package requirements to use newer, pinned versions of Django, `six`, and `django-rangefilter`.
  * Aligned dependency version settings across project files for more consistent installs and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->